### PR TITLE
Add new tests for Identity pages (#8817)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -1,80 +1,81 @@
 <Project>
   <ItemGroup>
-    <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management -->
-    <PackageVersion Include="Bit.Butil" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Bit.BlazorUI" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Bit.BlazorUI.Icons" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Bit.BlazorUI.Assets" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Bit.BlazorUI.Extras" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Bit.Bswup" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Bit.CodeAnalyzers" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Bit.SourceGenerators" Version="8.11.1-pre-04" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" />
-    <PackageVersion Include="EmbedIO" Version="3.5.2" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
-    <PackageVersion Include="Oscore.Maui.Android.InAppUpdates" Version="1.1.0" />
-    <PackageVersion Include="Oscore.Maui.AppStoreInfo" Version="1.0.7" />
-    <PackageVersion Include="Oscore.Maui.InAppReviews" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.91" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
-    <PackageVersion Include="Velopack" Version="0.0.626" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="8.0.0" />
-    <!--/+:msbuild-conditional:noEmit -->
-    <PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Bit.Besql" Version="8.11.1-pre-04" />
-    <PackageVersion Condition=" '$(signalr)' == 'true' OR '$(signalr)' == ''" Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
-    <PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
-    <PackageVersion Condition="'$(sample)' == 'Admin' OR '$(sample)' == ''" Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Condition=" '$(appCenter)' == 'true' OR '$(appCenter)' == '' " Include="Microsoft.AppCenter.Analytics" Version="5.0.5" />
-    <PackageVersion Condition=" '$(appCenter)' == 'true' OR '$(appCenter)' == '' " Include="Microsoft.AppCenter.Crashes" Version="5.0.5" />
-    <PackageVersion Condition=" '$(appCenter)' == 'true' OR '$(appCenter)' == '' " Include="West.Extensions.Logging.AppCenter" Version="2.2.2" />
-    <PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
-    <PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="BlazorApplicationInsights" Version="3.1.0" />
-    <PackageVersion Condition=" '$(database)' == 'SqlServer' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageVersion Condition=" '$(database)' == 'Sqlite' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
-    <PackageVersion Condition=" '$(database)' == 'PostgreSQL' OR '$(database)' == '' " Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
-    <PackageVersion Condition=" '$(database)' == 'Cosmos' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.8" />
-    <PackageVersion Condition=" '$(database)' == 'MySql' OR '$(database)' == '' " Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-    <PackageVersion Condition=" '$(filesStorage)' == 'AzureBlobStorage' OR '$(filesStorage)' == '' " Include="FluentStorage.Azure.Blobs" Version="5.2.5" />
-    <PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <!--/-:msbuild-conditional:noEmit -->
-    <PackageVersion Include="Humanizer" Version="2.14.1" />
-    <PackageVersion Include="QRCoder" Version="1.6.0" />
-    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.0.0" />
-    <PackageVersion Include="FluentEmail.Smtp" Version="3.0.2" />
-    <PackageVersion Include="FluentStorage" Version="5.5.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.8.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="8.0.8" />
-    <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.2.0" />
-    <PackageVersion Include="Riok.Mapperly" Version="3.6.0" />
-    <PackageVersion Include="Twilio" Version="7.4.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FakeItEasy" Version="8.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.47.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
+	<!-- https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management -->
+	<PackageVersion Include="Bit.Butil" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Bit.BlazorUI" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Bit.BlazorUI.Icons" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Bit.BlazorUI.Assets" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Bit.BlazorUI.Extras" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Bit.Bswup" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Bit.CodeAnalyzers" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Bit.SourceGenerators" Version="8.11.1-pre-04" />
+	<PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" />
+	<PackageVersion Include="EmbedIO" Version="3.5.2" />
+	<PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+	<PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+	<PackageVersion Include="Oscore.Maui.Android.InAppUpdates" Version="1.1.0" />
+	<PackageVersion Include="Oscore.Maui.AppStoreInfo" Version="1.0.7" />
+	<PackageVersion Include="Oscore.Maui.InAppReviews" Version="1.0.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.91" />
+	<PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+	<PackageVersion Include="Velopack" Version="0.0.626" />
+	<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+	<PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+	<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+	<PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.0" />
+	<PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="8.0.0" />
+	<!--/+:msbuild-conditional:noEmit -->
+	<PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Bit.Besql" Version="8.11.1-pre-04" />
+	<PackageVersion Condition=" '$(signalr)' == 'true' OR '$(signalr)' == ''" Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
+	<PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+	<PackageVersion Condition="'$(sample)' == 'Admin' OR '$(sample)' == ''" Include="Newtonsoft.Json" Version="13.0.3" />
+	<PackageVersion Condition=" '$(appCenter)' == 'true' OR '$(appCenter)' == '' " Include="Microsoft.AppCenter.Analytics" Version="5.0.5" />
+	<PackageVersion Condition=" '$(appCenter)' == 'true' OR '$(appCenter)' == '' " Include="Microsoft.AppCenter.Crashes" Version="5.0.5" />
+	<PackageVersion Condition=" '$(appCenter)' == 'true' OR '$(appCenter)' == '' " Include="West.Extensions.Logging.AppCenter" Version="2.2.2" />
+	<PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
+	<PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="BlazorApplicationInsights" Version="3.1.0" />
+	<PackageVersion Condition=" '$(database)' == 'SqlServer' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+	<PackageVersion Condition=" '$(database)' == 'Sqlite' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+	<PackageVersion Condition=" '$(database)' == 'PostgreSQL' OR '$(database)' == '' " Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
+	<PackageVersion Condition=" '$(database)' == 'Cosmos' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.8" />
+	<PackageVersion Condition=" '$(database)' == 'MySql' OR '$(database)' == '' " Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+	<PackageVersion Condition=" '$(filesStorage)' == 'AzureBlobStorage' OR '$(filesStorage)' == '' " Include="FluentStorage.Azure.Blobs" Version="5.2.5" />
+	<PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+	<!--/-:msbuild-conditional:noEmit -->
+	<PackageVersion Include="Humanizer" Version="2.14.1" />
+	<PackageVersion Include="QRCoder" Version="1.6.0" />
+	<PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.0.0" />
+	<PackageVersion Include="FluentEmail.Smtp" Version="3.0.2" />
+	<PackageVersion Include="FluentStorage" Version="5.5.1" />
+	<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.0.0" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8" />
+	<PackageVersion Include="Swashbuckle.AspNetCore" Version="6.8.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="8.0.8" />
+	<PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.2.0" />
+	<PackageVersion Include="Riok.Mapperly" Version="3.6.0" />
+	<PackageVersion Include="Twilio" Version="7.4.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+	<PackageVersion Include="Microsoft.Extensions.Localization" Version="8.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+	<PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+	<PackageVersion Include="System.Text.Json" Version="8.0.4" />
+	<PackageVersion Include="coverlet.collector" Version="6.0.2" />
+	<PackageVersion Include="FakeItEasy" Version="8.3.0" />
+	<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+	<PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.47.0" />
+	<PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
+	<PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
+	<PackageVersion Include="MsgReader" Version="5.6.5" />
   </ItemGroup>
 </Project>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/GoogleRecaptchaHttpClient.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/GoogleRecaptchaHttpClient.cs
@@ -6,7 +6,7 @@ public partial class GoogleRecaptchaHttpClient
 
     [AutoInject] protected HttpClient httpClient = default!;
 
-    public async ValueTask<bool> Verify(string? googleRecaptchaResponse, CancellationToken cancellationToken)
+    public virtual async ValueTask<bool> Verify(string? googleRecaptchaResponse, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(googleRecaptchaResponse)) return false;
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/.runsettings
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/.runsettings
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <Playwright>
+    <LaunchOptions>
+      <!--<Headless>true</Headless>-->
+      <!--<SlowMo>1000</SlowMo>-->
+    </LaunchOptions>
+    <!--<BrowserName>chromium</BrowserName>-->
+  </Playwright>
+
+  <MSTest>
+    <Parallelize>
+        <Workers>32</Workers>
+        <Scope>MethodLevel</Scope>
+    </Parallelize>
+  </MSTest>
+
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <!--<HEADED>1</HEADED>-->
+      <!--<PWDEBUG>1</PWDEBUG>-->
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/ApiTests/IdentityApiTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/ApiTests/IdentityApiTests.cs
@@ -1,22 +1,16 @@
 ﻿using Boilerplate.Client.Core.Services;
 using Boilerplate.Shared.Controllers.Identity;
+using Boilerplate.Tests.TestBase;
 
-namespace Boilerplate.Tests;
+namespace Boilerplate.Tests.ApiTests;
 
 [TestClass]
-public class IdentityApiTests
+public class IdentityApiTests : ApiTestBase
 {
     [TestMethod]
     public async Task SignInTest()
     {
-        await using var server = new AppTestServer();
-
-        await server.Build(services =>
-        {
-            // Services registered in this test project will be used instead of the application's services, allowing you to fake certain behaviors during testing.
-        }).StartAsync();
-
-        await using var scope = server.Services.CreateAsyncScope();
+        await using var scope = Services.CreateAsyncScope();
 
         var authenticationManager = scope.ServiceProvider.GetRequiredService<AuthenticationManager>();
 
@@ -36,11 +30,7 @@ public class IdentityApiTests
     [TestMethod, ExpectedException(typeof(UnauthorizedException))]
     public async Task UnauthorizedAccessTest()
     {
-        await using var server = new AppTestServer();
-
-        await server.Build().StartAsync();
-
-        await using var scope = server.Services.CreateAsyncScope();
+        await using var scope = Services.CreateAsyncScope();
 
         var userController = scope.ServiceProvider.GetRequiredService<IUserController>();
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsTestProject>true</IsTestProject>
+        <RunSettingsFilePath>$(MSBuildProjectDirectory)\.runsettings</RunSettingsFilePath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,6 +17,7 @@
         <PackageReference Include="Microsoft.Playwright.MSTest" />
         <PackageReference Include="MSTest.TestAdapter" />
         <PackageReference Include="MSTest.TestFramework" />
+        <PackageReference Include="MsgReader" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.sln
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Boilerplate.Tests", "Boilerplate.Tests.csproj", "{B29163E6-87EA-40EF-8F49-4419117E369A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B29163E6-87EA-40EF-8F49-4419117E369A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B29163E6-87EA-40EF-8F49-4419117E369A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B29163E6-87EA-40EF-8F49-4419117E369A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B29163E6-87EA-40EF-8F49-4419117E369A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {91883FA9-FD57-4975-A0D4-BEF17C9866C7}
+	EndGlobalSection
+EndGlobal

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Extensions/WebApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@ using Boilerplate.Client.Core.Services.Contracts;
 
 namespace Microsoft.AspNetCore.Builder;
 
-public static partial class WebApplicationBuilderExtensions
+public static class WebApplicationBuilderExtensions
 {
     public static void AddTestProjectServices(this WebApplicationBuilder builder)
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/IdentityPagesTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/IdentityPagesTests.cs
@@ -1,23 +1,51 @@
-﻿using System.Text.RegularExpressions;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Playwright;
 using Microsoft.Playwright.MSTest;
 
 namespace Boilerplate.Tests;
 
 [TestClass]
-public partial class IdentityPagesTests : PageTest
+public class IdentityPagesTests : PageTest
 {
     [TestMethod]
-    public async Task SignInTest()
+    public async Task UnauthorizedUser_Should_RedirectToSignInPage()
     {
         await using var server = new AppTestServer();
 
         await server.Build(services =>
         {
             // Services registered in this test project will be used instead of the application's services, allowing you to fake certain behaviors during testing.
-        }).Start();
+        }).StartAsync();
 
-        await Page.GotoAsync(new Uri(server.GetServerAddress(), Urls.ProfilePage).ToString());
+        var response = await Page.GotoAsync(new Uri(server.ServerAddress, Urls.ProfilePage).ToString());
 
-        await Expect(Page).ToHaveURLAsync(new Regex(@".*sign-in\?return-url=profile"));
+        Assert.IsNotNull(response);
+        Assert.AreEqual(StatusCodes.Status200OK, response.Status);
+
+        await Expect(Page).ToHaveURLAsync(new Uri(server.ServerAddress, "/sign-in?return-url=profile").ToString());
+    }
+
+    [TestMethod]
+    public async Task SignIn_Should_WorkAsExpected()
+    {
+        await using var server = new AppTestServer();
+        await server.Build().StartAsync();
+
+        var response = await Page.GotoAsync(new Uri(server.ServerAddress, Urls.SignInPage).ToString());
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(StatusCodes.Status200OK, response.Status);
+
+        const string email = "test@bitplatform.dev";
+        const string password = "123456";
+
+        await Page.GetByPlaceholder("Enter email address").FillAsync(email);
+        await Page.GetByPlaceholder("Enter password").FillAsync(password);
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Sign in" }).ClickAsync();
+
+        await Assertions.Expect(Page).ToHaveURLAsync(server.ServerAddress.ToString());
+        await Expect(Page.Locator(".persona")).ToBeVisibleAsync();
+        await Expect(Page.Locator(".persona")).ToContainTextAsync("Boilerplate test account");
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Sign Out" })).ToBeVisibleAsync();
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/MSTestSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 100)]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/PageTests/IdentityPagesTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/PageTests/IdentityPagesTests.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.Playwright;
+using Microsoft.AspNetCore.Http;
+using Boilerplate.Tests.Services;
+using Boilerplate.Tests.TestBase;
+using Boilerplate.Server.Api.Services;
+using Boilerplate.Tests.PageTests.PageModels;
+
+namespace Boilerplate.Tests.PageTests;
+
+[TestClass]
+public class IdentityPagesTests : PageTestBase
+{
+    private string signInText = "Sign in"; //TODO: multi-language test
+    private string signOutText = "Sign out"; //TODO: multi-language test
+    private string invalidCredentials = "Invalid user credentials"; //TODO: multi-language test
+
+    [TestMethod]
+    public async Task UnauthorizedUser_Should_RedirectToSignInPage()
+    {
+        var response = await Page.GotoAsync(new Uri(ServerAddress, Urls.ProfilePage).ToString());
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(StatusCodes.Status200OK, response.Status);
+
+        await Expect(Page).ToHaveURLAsync(new Uri(ServerAddress, "/sign-in?return-url=profile").ToString());
+    }
+
+    [TestMethod]
+    public async Task SignIn_Should_Work_With_ValidCredentials()
+    {
+        var singinPage = new SingInPage(Page, ServerAddress);
+
+        await singinPage.GotoAsync();
+        await singinPage.SignInAsync();
+
+        await Expect(Page).ToHaveURLAsync(ServerAddress.ToString());
+        await Expect(Page.Locator(".persona")).ToBeVisibleAsync();
+        await Expect(Page.Locator(".persona")).ToContainTextAsync("Boilerplate test account");
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = signOutText })).ToBeVisibleAsync();
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = signInText })).ToBeVisibleAsync(new() { Visible = false });
+    }
+
+    [TestMethod]
+    public async Task SignIn_Should_Fail_With_InvalidCredentials()
+    {
+        var singinPage = new SingInPage(Page, ServerAddress);
+
+        await singinPage.GotoAsync();
+        await singinPage.SignInAsync(password: "invalid_password");
+
+        await Expect(Page.GetByText(invalidCredentials)).ToBeVisibleAsync();
+        await Expect(Page.Locator(".persona")).ToBeVisibleAsync(new() { Visible = false });
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = signInText })).ToBeVisibleAsync();
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = signOutText })).ToBeVisibleAsync(new() { Visible = false });
+    }
+
+    [TestMethod]
+    public async Task SignOut_Should_WorkAsExpected()
+    {
+        var singinPage = new SingInPage(Page, ServerAddress);
+
+        await singinPage.GotoAsync();
+        await singinPage.SignInAsync();
+        await singinPage.SignOutAsync();
+
+        await Expect(Page).ToHaveURLAsync(ServerAddress.ToString());
+        await Expect(Page.Locator(".persona")).ToBeVisibleAsync(new() { Visible = false });
+        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = signInText })).ToBeVisibleAsync();
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = signOutText })).ToBeVisibleAsync(new() { Visible = false });
+    }
+
+    [TestMethod]
+    public async Task SignUp_Should_WorkAsExpected()
+    {
+        await using var testServer = new AppTestServer();
+
+        await testServer.Build(services =>
+        {
+            var descriptor = ServiceDescriptor.Transient<GoogleRecaptchaHttpClient, FakeGoogleRecaptchaHttpClient>();
+            services.Replace(descriptor);
+        }).StartAsync();
+
+        var singupPage = new SingUpPage(Page, testServer.ServerAddress);
+
+        await singupPage.GotoAsync();
+        await singupPage.SingUpAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/PageTests/PageModels/SingInPage.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/PageTests/PageModels/SingInPage.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Playwright;
+using Microsoft.AspNetCore.Http;
+
+namespace Boilerplate.Tests.PageTests.PageModels;
+
+public class SingInPage(IPage page, Uri serverAddress)
+{
+    public bool IsSignedIn { get; private set; }
+
+    private string enterEmailText = "Enter email address"; //TODO: multi-language test
+    private string enterPasswordText = "Enter password"; //TODO: multi-language test
+    private string signInText = "Sign in"; //TODO: multi-language test
+    private string signOutText = "Sign out"; //TODO: multi-language test
+
+    public async Task<IResponse?> GotoAsync()
+    {
+        var response = await page.GotoAsync(new Uri(serverAddress, Urls.SignInPage).ToString());
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(StatusCodes.Status200OK, response.Status);
+
+        return response;
+    }
+
+    public async Task SignInAsync(string email = "test@bitplatform.dev", string password = "123456")
+    {
+        await page.GetByPlaceholder(enterEmailText).FillAsync(email);
+        await page.GetByPlaceholder(enterPasswordText).FillAsync(password);
+        await page.GetByRole(AriaRole.Button, new() { Name = signInText }).ClickAsync();
+
+        IsSignedIn = true;
+    }
+
+    public async Task SignOutAsync()
+    {
+        Assert.IsTrue(IsSignedIn, "You must sign-in first.");
+
+        await page.GetByRole(AriaRole.Button, new() { Name = signOutText }).ClickAsync();
+        await page.GetByRole(AriaRole.Dialog).GetByRole(AriaRole.Button, new() { Name = signOutText }).ClickAsync();
+
+        IsSignedIn = false;
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/PageTests/PageModels/SingUpPage.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/PageTests/PageModels/SingUpPage.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Playwright;
+using Microsoft.AspNetCore.Http;
+using System.Text.RegularExpressions;
+
+namespace Boilerplate.Tests.PageTests.PageModels;
+
+public class SingUpPage(IPage page, Uri serverAddress)
+{
+    public async Task<IResponse> GotoAsync()
+    {
+        var response = await page.GotoAsync(new Uri(serverAddress, Urls.SignUpPage).ToString());
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(StatusCodes.Status200OK, response.Status);
+
+        //Override behavior of the javascript recaptcha function on the browser
+        await page.WaitForFunctionAsync("window.grecaptcha !== undefined");
+        await page.EvaluateAsync("window.grecaptcha.getResponse = () => 'not-empty';");
+
+        return response;
+    }
+
+    public async Task SingUpAsync(bool usingMagicLink = true)
+    {
+        var email = $"{Guid.NewGuid()}@gmail.com";
+
+        await page.GetByPlaceholder("Enter email address").FillAsync(email);
+        await page.GetByPlaceholder("Enter password").FillAsync("123456");
+        await page.GetByRole(AriaRole.Button, new() { Name = "Sign up", Exact = true }).ClickAsync();
+
+        await Assertions.Expect(page.GetByRole(AriaRole.Button, new() { Name = "Confirm Email Address" })).ToBeVisibleAsync();
+
+        var html = ReadEmlAndGetHtmlBody(email);
+        var emailPage = await page.Context.NewPageAsync();
+        await emailPage.SetContentAsync(html);
+
+
+        if (usingMagicLink)
+        {
+            var optLink = emailPage.GetByRole(AriaRole.Link, new() { Name = new Uri(serverAddress, Urls.ConfirmPage).ToString() });
+            await Assertions.Expect(optLink).ToBeVisibleAsync();
+            await optLink.ClickAsync();
+        }
+        else
+        {
+            var optCode = await emailPage.GetByText(new Regex("^\\d{6}$")).TextContentAsync();
+            await page.GetByPlaceholder("Enter code").FillAsync(optCode);
+            await page.GetByRole(AriaRole.Button, new() { Name = "Confirm Email Address" }).ClickAsync();
+        }
+
+        var signInText = "Sign in"; //TODO: multi-language test
+        var signOutText = "Sign out"; //TODO: multi-language test
+
+        await Assertions.Expect(emailPage).ToHaveURLAsync(serverAddress.ToString());
+        await Assertions.Expect(emailPage.Locator(".persona")).ToBeVisibleAsync();
+        await Assertions.Expect(emailPage.Locator(".persona")).ToContainTextAsync(email);
+        await Assertions.Expect(emailPage.GetByRole(AriaRole.Button, new() { Name = signOutText })).ToBeVisibleAsync();
+        await Assertions.Expect(emailPage.GetByRole(AriaRole.Button, new() { Name = signInText })).ToBeVisibleAsync(new() { Visible = false });
+
+        await emailPage.CloseAsync();
+    }
+
+    private static string ReadEmlAndGetHtmlBody(string toMailAddress)
+    {
+        var emailsDirectory = Path.Combine(AppContext.BaseDirectory, "App_Data", "sent-emails");
+        var emlFileInfo = new DirectoryInfo(emailsDirectory).GetFiles().MaxBy(f => f.CreationTime);
+        var eml = MsgReader.Mime.Message.Load(emlFileInfo);
+
+        Assert.AreEqual(toMailAddress, eml.Headers.To[0].Address);
+        Assert.AreEqual("info@Boilerplate.com", eml.Headers.From.Address);
+        //TODO: multi-language test
+        Assert.AreEqual("Boilerplate app", eml.Headers.From.DisplayName);
+        Assert.IsTrue(Regex.IsMatch(eml.Headers.Subject, "^Boilerplate \\d{6} - Confirm your email address$"), "Email subject does not match.");
+
+        //TODO: multi-language test for HtmlBody
+        return eml.HtmlBody.GetBodyAsText();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Services/FakeGoogleRecaptchaHttpClient.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Services/FakeGoogleRecaptchaHttpClient.cs
@@ -1,0 +1,13 @@
+﻿using Boilerplate.Server.Api.Services;
+
+namespace Boilerplate.Tests.Services;
+
+public partial class FakeGoogleRecaptchaHttpClient : GoogleRecaptchaHttpClient
+{
+    public FakeGoogleRecaptchaHttpClient() : base(null, null) { }
+
+    public override ValueTask<bool> Verify(string? googleRecaptchaResponse, CancellationToken cancellationToken)
+    {
+        return ValueTask.FromResult(true);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/TestBase/ApiTestBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/TestBase/ApiTestBase.cs
@@ -1,0 +1,32 @@
+﻿namespace Boilerplate.Tests.TestBase;
+
+[TestClass]
+public class ApiTestBase
+{
+    private AppTestServer TestServer = null!;
+
+    public Uri ServerAddress { get; private set; } = null!;
+    public IServiceProvider Services { get; private set; } = null!;
+    public IConfiguration Configuration { get; private set; } = null!;
+
+    [TestInitialize]
+    public async Task InitializeTestServer()
+    {
+        TestServer = new AppTestServer();
+
+        await TestServer.Build(services =>
+        {
+            // Services registered in this test project will be used instead of the application's services, allowing you to fake certain behaviors during testing.
+        }).StartAsync();
+
+        Services = TestServer.Services;
+        ServerAddress = TestServer.ServerAddress;
+        Configuration = TestServer.Configuration;
+    }
+
+    [TestCleanup]
+    public ValueTask CleanupTestServer()
+    {
+        return TestServer.DisposeAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/TestBase/PageTestBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/TestBase/PageTestBase.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Playwright.MSTest;
+
+namespace Boilerplate.Tests.TestBase;
+
+[TestClass]
+public class PageTestBase : PageTest
+{
+    private AppTestServer TestServer = null!;
+
+    public Uri ServerAddress { get; private set; } = null!;
+    public IServiceProvider Services { get; private set; } = null!;
+    public IConfiguration Configuration { get; private set; } = null!;
+
+    [TestInitialize]
+    public async Task InitializeTestServer()
+    {
+        TestServer = new AppTestServer();
+
+        await TestServer.Build(services =>
+        {
+            // Services registered in this test project will be used instead of the application's services, allowing you to fake certain behaviors during testing.
+        }).StartAsync();
+
+        Services = TestServer.Services;
+        ServerAddress = TestServer.ServerAddress;
+        Configuration = TestServer.Configuration;
+    }
+
+    [TestCleanup]
+    public ValueTask CleanupTestServer()
+    {
+        return TestServer.DisposeAsync();
+    }
+}


### PR DESCRIPTION
Closes #8817

**Summary:**
- Add new tests for Identity pages
- Added `MsgReader` package to read `.eml` files and extract its html body
- Made `GoogleRecaptchaHttpClient.Verify` virtual and override it with `FakeGoogleRecaptchaHttpClient`
- Added `.runsettings` for Playwright and MSTest configurations.
- Refactored `AppTestServer` for improved readability and more properties.
- Added `Boilerplate.Tests.sln` due to the problem with loading solutions in vs code.
- Added `MSTestSettings.cs` for parallel test execution.
- Introduced page models SingInPage.cs and SingUpPage.cs for user authentication scenarios.

**New Tests:**
- `IdentityPagesTests.SignIn_Should_Work_With_ValidCredentials`
- `IdentityPagesTests.SignIn_Should_Fail_With_InvalidCredentials`
- `IdentityPagesTests.SignOut_Should_WorkAsExpected`
- `IdentityPagesTests.SignUp_Should_WorkAsExpected`
